### PR TITLE
Update CloudWatch metric alarm period for queue not empty from 10 to …

### DIFF
--- a/terraform/worker_scaling.tf
+++ b/terraform/worker_scaling.tf
@@ -76,7 +76,7 @@ resource "aws_cloudwatch_metric_alarm" "queue_not_empty" {
   evaluation_periods  = 1
   metric_name         = "ApproximateNumberOfMessagesVisible"
   namespace           = "AWS/SQS"
-  period              = 10
+  period              = 30
   statistic           = "Maximum"
   threshold           = 0
 


### PR DESCRIPTION
…30 seconds